### PR TITLE
Add detector columns to tjhe secret incident table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
+ifdef STEAMPIPE_INSTALL_DIR
+STEAMPIPE_DIR := $(STEAMPIPE_INSTALL_DIR)
+else
+STEAMPIPE_DIR := ~/.steampipe
+endif
+
 install:
-	go build -o  ~/.steampipe/plugins/hub.steampipe.io/plugins/francois2metz/gitguardian@latest/steampipe-plugin-gitguardian.plugin *.go
+	go build -o  ${STEAMPIPE_DIR}/plugins/hub.steampipe.io/plugins/francois2metz/gitguardian@latest/steampipe-plugin-gitguardian.plugin *.go

--- a/gitguardian/table_gitguardian_secret_incident.go
+++ b/gitguardian/table_gitguardian_secret_incident.go
@@ -39,6 +39,42 @@ func tableGitguardianSecretIncident(ctx context.Context) *plugin.Table {
 				Description: "Last trigger date.",
 			},
 			{
+				Name:        "detector_name",
+				Type:        proto.ColumnType_STRING,
+				Description: "Name of the detector.",
+				Transform:   transform.FromField("Detector.Name"),
+			},
+			{
+				Name:        "detector_display_name",
+				Type:        proto.ColumnType_STRING,
+				Description: "Display of the detector.",
+				Transform:   transform.FromField("Detector.DisplayName"),
+			},
+			{
+				Name:        "detector_nature",
+				Type:        proto.ColumnType_STRING,
+				Description: "Nature of the detector.",
+				Transform:   transform.FromField("Detector.Nature"),
+			},
+			{
+				Name:        "detector_family",
+				Type:        proto.ColumnType_STRING,
+				Description: "Family of the detector.",
+				Transform:   transform.FromField("Detector.Family"),
+			},
+			{
+				Name:        "detector_group_name",
+				Type:        proto.ColumnType_STRING,
+				Description: "Group name of the detector.",
+				Transform:   transform.FromField("Detector.DetectorGroupName"),
+			},
+			{
+				Name:        "detector_group_display_name",
+				Type:        proto.ColumnType_STRING,
+				Description: "Group display name of the detector.",
+				Transform:   transform.FromField("Detector.DetectorGroupDisplayName"),
+			},
+			{
 				Name:        "secret_hash",
 				Type:        proto.ColumnType_STRING,
 				Description: "Unique hash.",


### PR DESCRIPTION
Closes #7.

I'm not a go person but this seems to work:

![Screenshot 2023-07-30 at 17 15 03](https://github.com/francois2metz/steampipe-plugin-gitguardian/assets/1027207/07ba151c-281e-4a56-a5c1-2123871019cd)

I also made the makefile respect `STEAMPIPE_INSTALL_DIR` rather than use ~/.steampipe by default.